### PR TITLE
feat: add id as a value object

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,14 @@
 module github.com/mist-gopher/feature-tag
 
 go 1.22.0
+
+require (
+	github.com/google/uuid v1.6.0
+	github.com/stretchr/testify v1.9.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/id/id.go
+++ b/pkg/id/id.go
@@ -1,0 +1,24 @@
+// A value object abstraction of unique identifier
+package id
+
+import "github.com/google/uuid"
+
+type Id struct {
+	value string
+}
+
+func (i Id) Value() string {
+	return i.value
+}
+
+func (i Id) IsEqual(other Id) bool {
+	return i.value == other.value
+}
+
+func New() Id {
+	return Id{uuid.NewString()}
+}
+
+func FromString(v string) (Id, error) {
+	return Id{v}, uuid.Validate(v)
+}

--- a/pkg/id/id_test.go
+++ b/pkg/id/id_test.go
@@ -1,0 +1,35 @@
+package id_test
+
+import (
+	"testing"
+
+	"github.com/mist-gopher/feature-tag/pkg/id"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFromString(t *testing.T) {
+	t.Run("should return error when receive a invalid uuid", func(t *testing.T) {
+		input := "invalid"
+		v, err := id.FromString(input)
+		assert.NotNil(t, err)
+		assert.Equal(t, input, v.Value())
+	})
+
+	t.Run("should return nil error when receive a valid uuid", func(t *testing.T) {
+		input := "b595057d-b343-48dd-9350-ffe6e4ad68d8"
+		v, err := id.FromString(input)
+		assert.Nil(t, err)
+		assert.Equal(t, input, v.Value())
+	})
+}
+
+func TestIsEqual(t *testing.T) {
+	id1 := id.New()
+	id2, _ := id.FromString(id1.Value())
+	id3 := id.New()
+
+	assert.True(t, id1.IsEqual(id2))
+	assert.True(t, id2.IsEqual(id1))
+	assert.False(t, id3.IsEqual(id1))
+	assert.False(t, id2.IsEqual(id3))
+}


### PR DESCRIPTION
A value object can abstract the internal log to handle unique ids
allowing us to easily pick a better strategy - like uuid vs ulid or
whoever - in a single piece of code
