### PR TITLE
feat: structured logger

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,7 +1,20 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/mist-gopher/feature-tag/configs"
+	"github.com/mist-gopher/feature-tag/pkg/logger"
+)
 
 func main() {
-	fmt.Println("Hello World!")
+	config := configs.Load()
+	logger.Configure(config.LogLevel)
+
+	greeting := "Hello"
+	target := "World"
+	message := fmt.Sprintf("%s %s!", greeting, target)
+
+	slog.Info(message)
 }

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -1,0 +1,55 @@
+package configs
+
+import (
+	"flag"
+	"os"
+
+	"github.com/mist-gopher/feature-tag/pkg/logger"
+)
+
+type Configuration struct {
+	LogLevel logger.Level
+}
+
+type configflags struct {
+	debug bool
+}
+
+type configenv struct {
+	loglevel string
+}
+
+func loadflags() configflags {
+	var debug bool
+	flag.BoolVar(&debug, "debug", false, "set app to debug level")
+	flag.Parse()
+
+	return configflags{
+		debug: debug,
+	}
+}
+
+func loadenv() configenv {
+	return configenv{
+		loglevel: os.Getenv("LOG_LEVEL"),
+	}
+}
+
+func Load() Configuration {
+	f := loadflags()
+	e := loadenv()
+
+	level := logger.INFO
+
+	if e.loglevel != "" {
+		level = logger.Level(e.loglevel)
+	}
+
+	if f.debug {
+		level = logger.DEBUG
+	}
+
+	return Configuration{
+		LogLevel: level,
+	}
+}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,0 +1,40 @@
+package logger
+
+import (
+	"log/slog"
+	"os"
+)
+
+type Level string
+
+const (
+	INFO  Level = "INFO"
+	WARN  Level = "WARN"
+	ERROR Level = "ERROR"
+	DEBUG Level = "DEBUG"
+)
+
+var logLevel = map[Level]slog.Level{
+	INFO:  slog.LevelInfo,
+	WARN:  slog.LevelWarn,
+	ERROR: slog.LevelError,
+	DEBUG: slog.LevelDebug,
+}
+
+func Configure(l Level) {
+	level, ok := logLevel[l]
+
+	if !ok {
+		level = slog.LevelInfo
+	}
+
+	log := slog.New(slog.NewJSONHandler(
+		os.Stdout,
+		&slog.HandlerOptions{
+			Level: level,
+		},
+	))
+
+	slog.SetDefault(log)
+	slog.Info("logger denined to " + level.String())
+}


### PR DESCRIPTION
Add package to configure standard `log/slog` with devel definition by CLI flags or environment variables.

When this package is called on `main func` any other point of the app just need to import `log/slog` to consume  the configuration.
